### PR TITLE
Fixing bug when no events received before reconnect check.

### DIFF
--- a/src/services/husqvarna/automower/eventStreamService.ts
+++ b/src/services/husqvarna/automower/eventStreamService.ts
@@ -84,6 +84,8 @@ export class EventStreamServiceImpl implements EventStreamService {
         this.startKeepAlive();
 
         this.setStarted(new Date());
+        this.setLastEventReceived(undefined);
+
         this.flagAsStarted();
     }
 
@@ -143,6 +145,10 @@ export class EventStreamServiceImpl implements EventStreamService {
         }
         
         return Promise.resolve(undefined);
+    }
+
+    protected getStarted(): Date | undefined {
+        return this.started;
     }
 
     protected setStarted(value?: Date): void {
@@ -242,6 +248,7 @@ export class EventStreamServiceImpl implements EventStreamService {
         await this.connect();
 
         this.setStarted(new Date());
+        this.setLastEventReceived(undefined);
     }
 
     protected pingOnce(): void {
@@ -280,6 +287,10 @@ export class EventStreamServiceImpl implements EventStreamService {
         this.timer.stop();
     }
 
+    protected getLastEventReceived(): Date | undefined {
+        return this.lastEventReceived;
+    }
+    
     protected setLastEventReceived(value?: Date): void {
         this.lastEventReceived = value;
     }

--- a/test/services/husqvarna/automower/eventStreamServiceImpl.spec.ts
+++ b/test/services/husqvarna/automower/eventStreamServiceImpl.spec.ts
@@ -41,7 +41,9 @@ describe('EventStreamServiceImpl', () => {
 
         expect(stream.opened).toBeTruthy();
         expect(stream.callbackSet).toBeTruthy();
-
+        expect(target.unsafeGetStarted()).toBeDefined();
+        expect(target.unsafeGetLastEventReceived()).toBeUndefined();
+        
         timer.verify(o => o.start(It.IsAny<(() => void)>(), It.IsAny<number>()), Times.Once());
     });
 
@@ -291,8 +293,10 @@ describe('EventStreamServiceImpl', () => {
 
         await target.unsafeKeepAlive();        
 
-        expect(stream.closed).toBeTruthy();        
+        expect(stream.closed).toBeTruthy();
         expect(stream.opened).toBeTruthy();
+        expect(target.unsafeGetStarted()).toBeDefined();
+        expect(target.unsafeGetLastEventReceived()).toBeUndefined();
     });
 
     it('should do nothing when settings-event is received', async () => {

--- a/test/services/husqvarna/automower/eventStreamServiceImplSpy.ts
+++ b/test/services/husqvarna/automower/eventStreamServiceImplSpy.ts
@@ -22,9 +22,17 @@ export class EventStreamServiceImplSpy extends EventStreamServiceImpl {
 
         return Promise.resolve(undefined);
     }
+
+    public unsafeGetLastEventReceived(): Date | undefined {
+        return this.getLastEventReceived();
+    }
     
     public unsafeSetLastEventReceived(value?: Date): void {
         this.setLastEventReceived(value);
+    }
+
+    public unsafeGetStarted(): Date | undefined {
+        return this.getStarted();
     }
 
     public unsafeSetStarted(value?: Date): void {


### PR DESCRIPTION
Resolves #161 