### PR TITLE
Correcting the pre-release version number.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
         registry-url: 'https://registry.npmjs.org/'
 
-    - run: npm version preminor --preid preview.${GITHUB_RUN_NUMBER}+${GITHUB_SHA::8} --no-git-tag-version
+    - run: npm version preminor --preid preview.${GITHUB_RUN_NUMBER}+${GITHUB_SHA::7} --no-git-tag-version
     - run: npm publish --tag next
       env:
         NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
Changing the git commit hash to 7 characters instead of 8. This is to ensure continuity between what GitHub displays on the website and what the user would see in the Homebridge user interface.