### PR TITLE
Fixing issue when outside cutting window.

### DIFF
--- a/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
+++ b/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
@@ -39,13 +39,13 @@ export class AutomowerMowerStateConverterImpl implements AutomowerMowerStateConv
             return model.Activity.OFF;
         }
 
-        if (mower.mode === Mode.MAIN_AREA || mower.mode === Mode.SECONDARY_AREA) {
-            return model.Activity.MOWING;
-        }
-
-        if (mower.mode === Mode.HOME) {
+        if (mower.mode === Mode.HOME || (mower.mode === Mode.MAIN_AREA && mower.state === State.RESTRICTED)) {
             return model.Activity.PARKED;
         }
+
+        if (mower.mode === Mode.MAIN_AREA || mower.mode === Mode.SECONDARY_AREA) {
+            return model.Activity.MOWING;
+        }        
         
         this.log.debug('VALUE_NOT_SUPPORTED', mower.activity);
         return model.Activity.UNKNOWN;
@@ -60,7 +60,7 @@ export class AutomowerMowerStateConverterImpl implements AutomowerMowerStateConv
             return model.State.CHARGING;
         }
 
-        if (mower.mode === Mode.HOME && mower.activity === Activity.PARKED_IN_CS) {
+        if (mower.activity === Activity.PARKED_IN_CS) {
             return model.State.IDLE;
         }
         
@@ -79,7 +79,6 @@ export class AutomowerMowerStateConverterImpl implements AutomowerMowerStateConv
             case State.ERROR:
             case State.ERROR_AT_POWER_UP:
             case State.FATAL_ERROR:
-            case State.RESTRICTED:
             case State.STOPPED:
                 return model.State.FAULTED;
 


### PR DESCRIPTION
The behavior seen from Husqvarna when a mower is outside of the cutting window and waiting in the charge station looks like:
```json
{
  "mode": "MAIN_AREA",
  "activity": "PARKED_IN_CS"
  "state": "RESTRICTED"
}
```
The issue was also that when it was outside of the window, it was also incorrectly reporting that the mower was actually mowing (because of MAIN_AREA) when in reality it was sitting in the charge station.

The mower should now correctly report that it's PARKED, and IDLE to HomeKit.

Resolves #356 