### PR TITLE
Fixing issue with reporting incorrect state when out of battery

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -70,6 +70,35 @@
             ]
           }
         },
+        "logger_type": {
+          "title": "Logging",
+          "type": "string",
+          "description": "This determines how your plugin logs statements. The default logger doesn't do debugging.",
+          "required": true,
+          "default": "default",
+          "enum": [
+            "default",
+            "imitation",
+            "force_debug"
+          ],
+          "x-schema-form": {
+            "type": "select",
+            "titleMap": [
+              {
+                "value": "default",
+                "name": "Default - Homebridge stock logger"
+              },
+              {
+                "value": "imitation",
+                "name": "Imitation - Looks like the default logger but includes debugging support"
+              },
+              {
+                "value": "force_debug",
+                "name": "Force debug statements"
+              }
+            ]
+          }
+        },
         "username": {
           "title": "Email Address",
           "type": "string",
@@ -187,6 +216,7 @@
       },
       "device_type",
       "sensor_mode",
+      "logger_type",
       {
         "type": "fieldset",
         "title": "Account Settings",

--- a/src/clients/automower/automowerClient.ts
+++ b/src/clients/automower/automowerClient.ts
@@ -9,17 +9,28 @@ import { FetchClient, Response } from '../fetchClient';
 export interface Mower {
     type: string;
     id: string;    
-    attributes: {
-        system: Device;
-        battery: Battery;
-        mower: MowerState;
-        calendar: Calendar;
-        planner: Planner;
-        metadata: MowerMetadata;
-        positions: Position[];
-        settings: Settings;
-        statistics: Statistics;
-    };
+    attributes: MowerAttributes;
+}
+
+/**
+ * Describes the mower attributes.
+ */
+export interface MowerAttributes extends StatusAttributes {
+    system: Device;
+    calendar: Calendar;
+    positions: Position[];
+    settings: Settings;
+    statistics: Statistics;
+}
+
+/**
+ * Describes status attributes.
+ */
+export interface StatusAttributes {
+    battery: Battery;
+    mower: MowerState;
+    planner: Planner;
+    metadata: MowerMetadata;
 }
 
 /**

--- a/src/clients/automower/automowerEventStreamClient.ts
+++ b/src/clients/automower/automowerEventStreamClient.ts
@@ -2,7 +2,7 @@ import { PlatformLogger } from '../../diagnostics/platformLogger';
 import { AccessToken } from '../../model';
 import { WebSocketWrapper } from '../../primitives/webSocketWrapper';
 import { AbstractEventStreamClient, EventStreamClient } from '../eventStreamClient';
-import { Battery, Calendar, Headlight, MowerMetadata, MowerState, Planner, Position } from './automowerClient';
+import { Calendar, Headlight, Position, StatusAttributes } from './automowerClient';
 
 /**
  * Describes a connected event.
@@ -34,12 +34,7 @@ export enum AutomowerEventTypes {
  * Describes a status event.
  */
 export interface StatusEvent extends AutomowerEvent {
-    attributes: {
-        battery: Battery;
-        mower: MowerState;
-        planner: Planner;
-        metadata: MowerMetadata;
-    };
+    attributes: StatusAttributes;
 }
 
 /**

--- a/src/services/husqvarna/automower/automowerEventStreamService.ts
+++ b/src/services/husqvarna/automower/automowerEventStreamService.ts
@@ -88,7 +88,7 @@ export class AutomowerEventStreamService extends AbstractEventStreamService<Auto
                 connection: {
                     connected: event.attributes.metadata.connected
                 },
-                mower: this.stateConverter.convertMowerState(event.attributes.mower)
+                mower: this.stateConverter.convertStatusAttributes(event.attributes)
             }
         });
 

--- a/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
+++ b/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
@@ -1,6 +1,6 @@
 import * as model from '../../../../model';
 
-import { Activity, Mode, Mower, MowerState, State } from '../../../../clients/automower/automowerClient';
+import { Activity, Mode, Mower, MowerAttributes, MowerState, State, StatusAttributes } from '../../../../clients/automower/automowerClient';
 import { PlatformLogger } from '../../../../diagnostics/platformLogger';
 
 /**
@@ -14,23 +14,23 @@ export interface AutomowerMowerStateConverter {
     convertMower(mower: Mower): model.MowerState;
 
     /**
-     * Converts the mower state.
-     * @param mower The mower state to convert.
+     * Converts the status attributes.
+     * @param attributes The mower attributes to convert.
      */
-    convertMowerState(mower: MowerState): model.MowerState;
+    convertStatusAttributes(attributes: StatusAttributes): model.MowerState;
 }
 
 export class AutomowerMowerStateConverterImpl implements AutomowerMowerStateConverter {
     public constructor(private log: PlatformLogger) { }
     
     public convertMower(mower: Mower): model.MowerState {
-        return this.convertMowerState(mower.attributes.mower);
+        return this.convertStatusAttributes(mower.attributes);
     }
 
-    public convertMowerState(mower: MowerState): model.MowerState {
+    public convertStatusAttributes(attributes: StatusAttributes): model.MowerState {
         return {
-            activity: this.convertActivity(mower),
-            state: this.convertState(mower)
+            activity: this.convertActivity(attributes.mower),
+            state: this.convertState(attributes.mower)
         };
     }
 

--- a/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
+++ b/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
@@ -52,10 +52,10 @@ export class AutomowerMowerStateConverterImpl implements AutomowerMowerStateConv
     }
 
     protected convertState(mower: MowerState): model.State {
-        if (mower.activity === Activity.STOPPED_IN_GARDEN) {
+        if (mower.mode === Mode.SECONDARY_AREA && mower.activity === Activity.STOPPED_IN_GARDEN) {
             return model.State.FAULTED;
         }
-        
+
         if (mower.activity === Activity.CHARGING) {
             return model.State.CHARGING;
         }

--- a/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
+++ b/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
@@ -52,10 +52,6 @@ export class AutomowerMowerStateConverterImpl implements AutomowerMowerStateConv
     }
 
     protected convertState(mower: MowerState): model.State {
-        if (mower.state === State.STOPPED && mower.errorCode !== 0) {
-            return model.State.TAMPERED;
-        }
-
         if (mower.activity === Activity.CHARGING) {
             return model.State.CHARGING;
         }

--- a/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
+++ b/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
@@ -1,6 +1,6 @@
 import * as model from '../../../../model';
 
-import { Activity, Mode, Mower, MowerAttributes, MowerState, State, StatusAttributes } from '../../../../clients/automower/automowerClient';
+import { Activity, Mode, Mower, MowerState, State, StatusAttributes } from '../../../../clients/automower/automowerClient';
 import { PlatformLogger } from '../../../../diagnostics/platformLogger';
 
 /**

--- a/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
+++ b/src/services/husqvarna/automower/converters/automowerMowerStateConverter.ts
@@ -52,6 +52,10 @@ export class AutomowerMowerStateConverterImpl implements AutomowerMowerStateConv
     }
 
     protected convertState(mower: MowerState): model.State {
+        if (mower.activity === Activity.STOPPED_IN_GARDEN) {
+            return model.State.FAULTED;
+        }
+        
         if (mower.activity === Activity.CHARGING) {
             return model.State.CHARGING;
         }

--- a/test/services/husqvarna/automower/automowerEventStreamService.spec.ts
+++ b/test/services/husqvarna/automower/automowerEventStreamService.spec.ts
@@ -353,7 +353,7 @@ describe('AutomowerEventStreamService', () => {
             }
         };
 
-        stateConverter.setup(o => o.convertMowerState(mowerState)).returns({
+        stateConverter.setup(o => o.convertStatusAttributes(event.attributes)).returns({
             activity: model.Activity.MOWING,
             state: model.State.IN_OPERATION
         });

--- a/test/services/husqvarna/automower/converters/automowerMowerStateConverter.spec.ts
+++ b/test/services/husqvarna/automower/converters/automowerMowerStateConverter.spec.ts
@@ -45,7 +45,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
                 }
             };
 
-        const result = target.convertMowerState(mower.attributes.mower);
+        const result = target.convertStatusAttributes(mower.attributes);
 
         expect(result).toBeDefined();
         expect(result.activity).toEqual(model.Activity.PARKED);

--- a/test/services/husqvarna/automower/converters/automowerMowerStateConverter.spec.ts
+++ b/test/services/husqvarna/automower/converters/automowerMowerStateConverter.spec.ts
@@ -825,7 +825,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
         log.verify(o => o.debug(It.IsAny(), It.IsAny()), Times.Once());
     });   
 
-    it('should return tampered when stopped with error', () => {
+    it('should return faulted when stopped with error', () => {
         const mower: Mower = {
             id: '12345',
             type: 'mower',
@@ -890,7 +890,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
         const result = target.convertMower(mower);
 
         expect(result).toBeDefined();
-        expect(result.state).toEqual(model.State.TAMPERED);
+        expect(result.state).toEqual(model.State.FAULTED);
     });
 
     it('should return charging while mowing secondary area', () => {

--- a/test/services/husqvarna/automower/converters/automowerMowerStateConverter.spec.ts
+++ b/test/services/husqvarna/automower/converters/automowerMowerStateConverter.spec.ts
@@ -17,6 +17,78 @@ describe('AutomowerMowerStateConverterImpl', () => {
         target = new AutomowerMowerStateConverterImpl(log.object());
     });
 
+    it('should return faulted when battery has been depleted while mowing main area', () => {
+        const mower: StatusEvent = {
+            id: '12345',
+            type: AutomowerEventTypes.STATUS,
+            attributes:{
+                battery:{
+                    batteryPercent: 0
+                },
+                mower:{
+                    mode: Mode.MAIN_AREA,
+                    activity: Activity.NOT_APPLICABLE,
+                    state: State.PAUSED,
+                    errorCode: 0,
+                    errorCodeTimestamp: 0
+                },
+                planner:{
+                    nextStartTimestamp: 0,
+                    override:{
+                        action: OverrideAction.NOT_ACTIVE
+                    },
+                    restrictedReason: RestrictedReason.NOT_APPLICABLE
+                },
+                metadata:{
+                    connected: true,
+                    statusTimestamp: 1723315112510
+                }
+            }
+        };
+
+        const result = target.convertStatusAttributes(mower.attributes);
+
+        expect(result).toBeDefined();
+        expect(result.activity).toEqual(model.Activity.MOWING);
+        expect(result.state).toEqual(model.State.FAULTED);
+    });
+
+    it('should return faulted when battery has been depleted while mowing secondary area', () => {
+        const mower: StatusEvent = {
+            id: '12345',
+            type: AutomowerEventTypes.STATUS,
+            attributes:{
+                battery:{
+                    batteryPercent: 0
+                },
+                mower:{
+                    mode: Mode.SECONDARY_AREA,
+                    activity: Activity.NOT_APPLICABLE,
+                    state: State.PAUSED,
+                    errorCode: 0,
+                    errorCodeTimestamp: 0
+                },
+                planner:{
+                    nextStartTimestamp: 0,
+                    override:{
+                        action: OverrideAction.NOT_ACTIVE
+                    },
+                    restrictedReason: RestrictedReason.NOT_APPLICABLE
+                },
+                metadata:{
+                    connected: true,
+                    statusTimestamp: 1723315112510
+                }
+            }
+        };
+
+        const result = target.convertStatusAttributes(mower.attributes);
+
+        expect(result).toBeDefined();
+        expect(result.activity).toEqual(model.Activity.MOWING);
+        expect(result.state).toEqual(model.State.FAULTED);
+    });
+
     it('should return parked and idle when parked and outside of scheduled window', () => {
         const mower: StatusEvent = {
             id: '12345',
@@ -41,9 +113,10 @@ describe('AutomowerMowerStateConverterImpl', () => {
                 },
                 metadata:{
                     connected: true,
-                    statusTimestamp: 1723071500034}
+                    statusTimestamp: 1723071500034
                 }
-            };
+            }
+        };
 
         const result = target.convertStatusAttributes(mower.attributes);
 
@@ -893,7 +966,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
         expect(result.state).toEqual(model.State.FAULTED);
     });
 
-    it('should return charging while mowing secondary area', () => {
+    it('should return charging while mowing secondary area and battery has been depleted', () => {
         const mower: Mower = {
             id: '12345',
             type: 'mower',
@@ -935,7 +1008,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
                     serialNumber: 1
                 },
                 battery: {
-                    batteryPercent: 100
+                    batteryPercent: 80
                 },
                 calendar: {
                     tasks: [ 
@@ -962,7 +1035,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
         expect(result.state).toEqual(model.State.CHARGING);
     });
 
-    it('should return charging while mowing main area', () => {
+    it('should return charging while mowing main area and battery has been depleted', () => {
         const mower: Mower = {
             id: '12345',
             type: 'mower',
@@ -1004,7 +1077,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
                     serialNumber: 1
                 },
                 battery: {
-                    batteryPercent: 100
+                    batteryPercent: 80
                 },
                 calendar: {
                     tasks: [ 

--- a/test/services/husqvarna/automower/converters/automowerMowerStateConverter.spec.ts
+++ b/test/services/husqvarna/automower/converters/automowerMowerStateConverter.spec.ts
@@ -616,7 +616,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
         expect(result.state).toEqual(model.State.LEAVING_HOME);
     });
 
-    it('should return mowing when stopped in garden', () => {
+    it('should return faulted when stopped in garden', () => {
         const mower: Mower = {
             id: '12345',
             type: 'mower',
@@ -629,7 +629,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
                     activity: Activity.STOPPED_IN_GARDEN,
                     errorCode: 0,
                     errorCodeTimestamp: 0,
-                    mode: Mode.MAIN_AREA,
+                    mode: Mode.SECONDARY_AREA,
                     state: State.UNKNOWN
                 },
                 planner: {
@@ -682,7 +682,7 @@ describe('AutomowerMowerStateConverterImpl', () => {
 
         expect(result).toBeDefined();
         expect(result.activity).toEqual(model.Activity.MOWING);
-        expect(result.state).toEqual(model.State.UNKNOWN);
+        expect(result.state).toEqual(model.State.FAULTED);
     });
 
     it('should return mowing when mowing', () => {


### PR DESCRIPTION
Associated with #356 

These changes are all specific to Automower models:
- Added logger_type configuration support from the UI.
- Improved fault detection when mower is stopped.
- Fixed fault hits when stopped in garden.
- Added fault detection when device is at 0% battery.
- Removed tampered support due to variances in the mower models using different codes that mean different things. All tampered results will now be faulted.